### PR TITLE
Add sponsor linkage for primary contributor

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: [sursly]
+custom: ["https://www.paypal.me/tylerfinck"]

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
 github: [sursly]
-custom: ["https://www.paypal.me/tylerfinck"]
+custom: ["https://www.paypal.me/tylerfinck", "https://www.theleagueofmoveabletype.com/membership"]


### PR DESCRIPTION
As noted in issue #16 there are some font updates in @sursly's fork of this that need merging. I would like to put those off for a few days while I work on finishing #10 so that I don't have to cleanup the same messes so many times.

In the mean time this commit from the same fork has nothing to do with updates to the font itself and there is no reason to lump it in with them, it can be merged now.

As [mentioned in relation to League Mono](https://github.com/sursly/leaguemono/issues/5#issuecomment-636217206) I think at least the primary contributors to font projects like this should be able to have their link(s) of choice for sponsorship. Given that the lion's share of this font as published is from @sursly I think these links can and should be posted on the main repository.