### PR TITLE
Reset axis mappings and instance coordinates

### DIFF
--- a/sources/LeagueSpartan.glyphs
+++ b/sources/LeagueSpartan.glyphs
@@ -1,5 +1,5 @@
 {
-.appVersion = "1339";
+.appVersion = "1342";
 DisplayStrings = (
 "THE/space QUICK/space BROWN/space FOX/space JUMPS/space \012OVER/space THE/space LAZY/space DOG\012\012AMAZINGLY/space FEW/space DISCOTHEQUES/space \012PROVIDE/space JUKEBOXES\012\012the/space quick/space brown/space fox/space jumps/space over/space the/space lazy/space dog!\012/space \012League/space Spartan\012Amazingly/space few/space discotheques\012provide/space jukeboxes\012\012Allison/space Usavage\012Instagram\012Facebook\012SNAPCHAT\0120123456789",
 "/quotedblleft Fix,/space Schwyz!/quotedblright/space quäkt/space Jürgen/space blöd/space vom/space Paß/space \012/quotedblleft FIX,/space SCHWYZ!/quotedblright/space QUÄKT/space JÜRGEN/space BLÖD/space VOM/space PAß\012\012/quotedblleft Falsches/space Üben/space von/space Xylophonmusik/space quält/space jeden/space größeren/space Zwerg/quotedblright \012/quotedblleft FALSCHES/space ÜBEN/space VON/space XYLOPHONMUSIK/space QUÄLT/space JEDEN/space GRÖßEREN/space ZWERG/quotedblright \012Törkylempijävongahdus\012TÖRKYLEMPIJÄVONGsAHDUS\012\012Quizdeltagerne/space spiste/space jordbær/space med/space fløde,/space mens/space cirkusklovnen/space Walther/space \012spillede/space på/space xylofon./space \012\012QUIZDELTAGERNE/space SPISTE/space JORDBÆR/space MED/space FLØDE,/space MENS/space CIRKUSKLOVNEN/space WALTHER/space SPILLEDE/space PÅ/space XYLOFON\012\012Nech/tcaron/space ji/zcaron/space h/rcaron í/scaron né/space saxofony/space/dcaron ábl/uring/space rozezvu/ccaron í/space sí/ncaron/space úd/ecaron snými/space tóny/space waltzu/space \012tanga/space a/space quickstepu.\012NECH/Tcaron/space JI/Zcaron/space H/Rcaron Í/Scaron NÉ/space SAXOFONY/space/Dcaron ÁBL/Uring/space ROZEZVU/Ccaron Í/space SÍ/Ncaron/space ÚD/Ecaron SNÝMI/space TÓNY/space \012WALTZU,/space TANGA/space A/space QUICKSTEPU.\012\012Pchn/aogonek/cacute/space w/space t/eogonek/space/lslash ód/zacute/space je/zdotaccent a/space lub/space o/sacute m/space skrzy/nacute/space fig./space \012PCHN/Aogonek/Cacute/space W/space T/Eogonek/space/Lslash ÓD/Zacute/space JE/Zdotaccent A/space LUB/space O/Sacute M/space SKRZY/Nacute/space FIG.\012\012Luís/space argüia/space à/space Júlia/space que/space/quotedblleft bra¸ções,/space fé,/space chá,/space óxido,/space pôr,/space zângão/quotedblright/space eram/space \012palavras/space do/space português./space \012\012LUÍS/space ARGÜIA/space À/space JÚLIA/space QUE/space/quotedblleft BRAÇÕES,/space FÉ,/space CHÁ,/space ÓXIDO,/space PÔR,/space ZÂNGÃO/quotedblright/space ERAM/space PALAVRAS/space DO/space PORTUGUÊS./space \012\012K/racute de/lcaron/space/scaron/tcaron astných/space/dcaron at/lcaron ov/space u/ccaron í/space pri/space ústí/space Váhu/space m/lacute kveho/space ko/ncaron a/space obhrýza/tcaron/space kôru/space a/space \012/zcaron ra/tcaron/space/ccaron erstvé/space mäso.\012\012K/Racute DE/Lcaron/space/Scaron/Tcaron ASTNÝCH/space OV/space U/Ccaron Í/space PI/space ÚSTÍ/space VÁHU/space M/Lacute KVEHO/space KO/Ncaron A/space OBHRÝZA/Tcaron/space KOÔRU/space A/space/Zcaron RA/Tcaron/space C/Ccaron ERSTVÉ/space MÄSO.V\012DYDYDYDABAYBYÄlcatraz/space \012\012ALCATRAZ\012COULDN'T/space CARE/space LESS/quotedblleft/quoteleft Couldn't./quotedblright/quoteright \012TH",
@@ -58,8 +58,8 @@ name = "Axis Mappings";
 value = {
 wght = {
 200 = 200;
-300 = 277;
-400 = 380;
+300 = 300;
+400 = 400;
 500 = 500;
 600 = 600;
 700 = 700;
@@ -32520,11 +32520,11 @@ name = familyName;
 value = "League Spartan";
 }
 );
-interpolationWeight = 277;
+interpolationWeight = 300;
 interpolationWidth = 5;
 instanceInterpolations = {
-"9D4C2422-5CE9-4C2E-AAC7-BF869A02F5C8" = 0.89;
-"C45C3DCC-6617-4D42-8E57-0A4EECAD9C2E" = 0.11;
+"9D4C2422-5CE9-4C2E-AAC7-BF869A02F5C8" = 0.85714;
+"C45C3DCC-6617-4D42-8E57-0A4EECAD9C2E" = 0.14286;
 };
 name = Light;
 weightClass = Light;
@@ -32536,11 +32536,11 @@ name = familyName;
 value = "League Spartan";
 }
 );
-interpolationWeight = 380;
+interpolationWeight = 400;
 interpolationWidth = 5;
 instanceInterpolations = {
-"9D4C2422-5CE9-4C2E-AAC7-BF869A02F5C8" = 0.74286;
-"C45C3DCC-6617-4D42-8E57-0A4EECAD9C2E" = 0.25714;
+"9D4C2422-5CE9-4C2E-AAC7-BF869A02F5C8" = 0.71429;
+"C45C3DCC-6617-4D42-8E57-0A4EECAD9C2E" = 0.28571;
 };
 name = Regular;
 },
@@ -32622,7 +32622,7 @@ instanceInterpolations = {
 "C45C3DCC-6617-4D42-8E57-0A4EECAD9C2E" = 1;
 };
 name = Black;
-weightClass = ExtraBold;
+weightClass = Black;
 }
 );
 keepAlternatesTogether = 1;


### PR DESCRIPTION
This is my attempt to fix #29 (again), this time from Glyphs.app:

1. Open axis mappings and set all values to 1→1 mappings. Note that on the Glyphs axis graph this ended up with a straight line.
2. Open each instance and set the axis coordinate to the corresponding weight.
3. Set the weight class of the 900 instance to Black (the *name* already was "Black" but the weight class was "ExtraBold").

@sursly Does this sound sane to you? The result builds fine in current `fontship` (which under the hood is current `fontmake` and `gftools`) and the instances *look* even to me:

![image](https://user-images.githubusercontent.com/173595/97274691-10966080-1846-11eb-96e3-ed7ee7b42fa7.png)

However since I don't understand what problem the uneven axis mappings were supposed to be fixing in the first place I may not actually be qualified to say this is the way to go.